### PR TITLE
Changed default for minimal eigenvalue to 1

### DIFF
--- a/jamovi/efa.a.yaml
+++ b/jamovi/efa.a.yaml
@@ -77,10 +77,10 @@ options:
     - name: minEigen
       title: Minimum value
       type: Number
-      default: 0
+      default: 1
       description:
           R: >
-            a number (default: 0), the minimal eigenvalue for a factor to be included in the model
+            a number (default: 1), the minimal eigenvalue for a factor to be included in the model
 
     - name: extraction
       title: Extraction


### PR DESCRIPTION
1 is Kaiser's criterium (and even though it is discussed, 0 is rather less appropriate as default)